### PR TITLE
Fix(battery-demo): Stackblitz start command

### DIFF
--- a/apps/battery/angular/.stackblitzrc
+++ b/apps/battery/angular/.stackblitzrc
@@ -1,5 +1,5 @@
 {
   "installDependencies": true,
   "compileTrigger": "save",
-  "startCommand": "./node_modules/.bin/setup-nativescript-stackblitz && ns preview"
+  "startCommand": "./node_modules/.bin/preview-cli"
 }

--- a/apps/battery/javascript/.stackblitzrc
+++ b/apps/battery/javascript/.stackblitzrc
@@ -1,5 +1,5 @@
 {
   "installDependencies": true,
   "compileTrigger": "save",
-  "startCommand": "./node_modules/.bin/setup-nativescript-stackblitz && ns preview"
+  "startCommand": "./node_modules/.bin/preview-cli"
 }

--- a/apps/battery/react/.stackblitzrc
+++ b/apps/battery/react/.stackblitzrc
@@ -1,5 +1,5 @@
 {
   "installDependencies": true,
   "compileTrigger": "save",
-  "startCommand": "./node_modules/.bin/setup-nativescript-stackblitz && ns preview"
+  "startCommand": "./node_modules/.bin/preview-cli"
 }

--- a/apps/battery/svelte/.stackblitzrc
+++ b/apps/battery/svelte/.stackblitzrc
@@ -1,5 +1,5 @@
 {
   "installDependencies": true,
   "compileTrigger": "save",
-  "startCommand": "./node_modules/.bin/setup-nativescript-stackblitz && ns preview"
+  "startCommand": "./node_modules/.bin/preview-cli"
 }

--- a/apps/battery/typescript/.stackblitzrc
+++ b/apps/battery/typescript/.stackblitzrc
@@ -1,5 +1,5 @@
 {
   "installDependencies": true,
   "compileTrigger": "save",
-  "startCommand": "./node_modules/.bin/setup-nativescript-stackblitz && ns preview"
+  "startCommand": "./node_modules/.bin/preview-cli"
 }

--- a/apps/battery/vue/.stackblitzrc
+++ b/apps/battery/vue/.stackblitzrc
@@ -1,5 +1,5 @@
 {
   "installDependencies": true,
   "compileTrigger": "save",
-  "startCommand": "./node_modules/.bin/setup-nativescript-stackblitz && ns preview --no-hmr"
+  "startCommand": "./node_modules/.bin/preview-cli --no-hmr"
 }

--- a/apps/battery/vue/.stackblitzrc
+++ b/apps/battery/vue/.stackblitzrc
@@ -1,5 +1,5 @@
 {
   "installDependencies": true,
   "compileTrigger": "save",
-  "startCommand": "./node_modules/.bin/preview-cli --no-hmr"
+  "startCommand": "./node_modules/.bin/preview-cli"
 }


### PR DESCRIPTION
Fixes battery demos using wrong start command. 

Removes vue's --no-hmr flag too, I'm assuming this will get an update to Vue 3 soon anyway?